### PR TITLE
Use environment attribute

### DIFF
--- a/.delivery/build-cookbook/test/fixtures/cookbooks/test/recipes/default.rb
+++ b/.delivery/build-cookbook/test/fixtures/cookbooks/test/recipes/default.rb
@@ -1,6 +1,7 @@
 %w(unit lint syntax).each do |phase|
   # TODO: This works on Linux/Unix. Not Windows.
-  execute "HOME=/home/vagrant delivery job verify #{phase} --server localhost --ent test --org kitchen" do
+  execute "delivery job verify #{phase} --server localhost --ent test --org kitchen" do
+    environment HOME: '/home/vagrant'
     cwd '/tmp/repo-data'
     user 'vagrant'
   end


### PR DESCRIPTION
`execute` has an `environment` attribute that can be used to set the `HOME`.
